### PR TITLE
update install instructions for people who do not have nvm or npm installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 ```
 
-Now, install node:
+Now, install the the node Javascript runtime environment which includes the node package manager (npm):
 ```bash
 nvm install node
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export CONTENT_PATH="/path/to/your/content/repository"
 ### Install dependencies
 
 
-Check whether you have npm installed:
+Check whether you have node and npm installed:
 ```bash
 node -v
 npm -v

--- a/README.md
+++ b/README.md
@@ -37,16 +37,39 @@ git clone git@github.com:esciencecenter-digital-skills/NEBULA.git
 To make sure that NEBULA knows where to find the content, we create the following environment variable:
 
 ```bash
-export CONTENT_PATH="~/path/to/your/content/repository"
+export CONTENT_PATH="/path/to/your/content/repository"
 ```
 
 ### Install dependencies
 
-Install the dependencies using the [node package manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):
+
+Check whether you have npm installed:
+```bash
+node -v
+npm -v
+```
+The above commands should output the installed versions, *e.g.*, `10.6.0` and `v20.9.0`.
+
+If this is not the case, proceed with installing the [node package manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+First, [install nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script)
 
 ```bash
-# node package manager
-npm install
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+```
+
+Now, install node:
+```bash
+nvm install node
+```
+
+Finally, you can install the node package manager itself. Make sure you install it in the content repository directory
+```bash
+cd /path/to/your/content/repository
+npm install -g npm
 ```
 
 ### Local development build

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The above commands should output the installed versions, *e.g.*, `10.6.0` and `v
 
 If this is not the case, proceed with installing the [node package manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
-First, [install nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script)
+First, [use nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script), the "node version manager", this is a shell script that enables the installation, management and use of multiple versions of the node runtime environment and package manager.
 
 ```bash
 wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ nvm install node
 Finally, you can use npm (node package manager) to install the dependencies of NEBULA. Navigate to the NEBULA respository:
 ```bash
 cd /path/to/your/NEBULA/repository
-npm install -g npm
+npm install
 ```
 
 ### Local development build

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Now, install node:
 nvm install node
 ```
 
-Finally, you can install the node package manager itself. Make sure you install it in the content repository directory
+Finally, you can use npm (node package manager) to install the dependencies of NEBULA. Navigate to the NEBULA respository:
 ```bash
 cd /path/to/your/content/repository
 npm install -g npm

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ nvm install node
 
 Finally, you can use npm (node package manager) to install the dependencies of NEBULA. Navigate to the NEBULA respository:
 ```bash
-cd /path/to/your/content/repository
+cd /path/to/your/NEBULA/repository
 npm install -g npm
 ```
 


### PR DESCRIPTION
These are the instructions I just followed. They were found [here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm) and [here](https://github.com/nvm-sh/nvm/blob/master/README.md), but it was a bit of a hassle to delve through the links to find the specific instructions required.