### PR TITLE
reduce header size of 'Role of Research Software' from h1 to h2

### DIFF
--- a/modules/researchsoftware/further-reading.md
+++ b/modules/researchsoftware/further-reading.md
@@ -26,7 +26,7 @@ However for most practical purposes in most domains of scientific research (exce
 [Software vs. data in the context of citation](https://doi.org/10.7287/peerj.preprints.2630v1)
 
 
-# The role of Research Software
+## The role of Research Software
 
 The following piece was written after a workshop called "The Future of Research Software", held in the Netherlands in 2022.
 


### PR DESCRIPTION
Header of 'The role of Research Software' was title-sized instead of (sub)header sized. 