### PR TITLE
Fix disappearing org logo

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
         "repoOwner": "esciencecenter-digital-skills",
         "organization": "Netherlands eScience Center",
         "organizationURL": "https://www.esciencecenter.nl",
-        "organizationLogo": "main/media/nlesc-logo.svg",
+        "organizationLogo": "/main/media/nlesc-logo.svg",
         "categoryOrder": ["Getting Started", "Developing Software", "Sharing Software"]
     }
 }


### PR DESCRIPTION
Using a leading slash seems to build the orglogo url consistently. Otherwise it will disappear upon refresh when in a module.