### PR TITLE
Remove "storing results in branches"

### DIFF
--- a/modules/version-control/slides-version-control.md
+++ b/modules/version-control/slides-version-control.md
@@ -226,7 +226,6 @@ Branches here are indicated as "feature branches", i.e. branches used while crea
 
 Other uses of branches:
 - a sandbox or playground, for trying out different things without "damaging" the stable version
-- organizing/storing results alongside their different variations/settings
 - release management
 - custom/user specific changes
 - ...


### PR DESCRIPTION
From discussion with Ole and Robin, we decide to take out the sentence on "storing results in branches" from the speaker notes, as we do not recommend doing this.

fixes #178