### PR TITLE
Adding a slide about connecting to communities

### DIFF
--- a/modules/softwarelandscape/slides.md
+++ b/modules/softwarelandscape/slides.md
@@ -117,6 +117,24 @@ This is supported by many organisations, including UNESCO. The Netherlands recen
 
 ===
 
+<!-- .slide: data-state="standard" -->
+### What communities to connect to?
+**Overwhelmed?**
+- It might be hard to distinguish what initiatives try to tackle which problems
+- Some of the communities might be overlapping in people and goals
+- What communities might benefit the researchers of your insitute?
+- What communities would you recomment researchers to connect with?
+
+Let's do an exercise to explore these initiatives a bit better.
+
+Note: problems mentioned earlier in this slide deck include:
+- Software quality and sustainability
+- Reproducibility of research
+- Attribution for researchers writing code
+- Funding for research software
+
+===
+
 <!-- .slide: data-state="standard center" -->
 ## The FAIR principles
 


### PR DESCRIPTION
I suggest adding a slide after presenting the landscape to let people think about what communities they would advice researchers to connect with.

Partly fixes issue 134 comment of Jaro "The landscape slide should convey a specific message and show the various initiatives, solving different problems and how the movements sometimes have overlap and sometimes are in conflict."